### PR TITLE
Add e2hs spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Historical data providers offer **three primary storage formats**:
 - [**Era1**(Pre-Merge Execution History)](./formats/era1.md) - Archive nodes providing **execution layer history** before The Merge (ETH1).
 - [**Era**(Beacon Chain History)](./formats/era.md) - Stores data from the genesis of the Beacon Chain onwards. Can be used by Execution layer clients for history **from The Merge onward**, including historical block data.
 - [**E2SS**(Execution State)](./formats/e2ss.md) - **State snapshots** for execution clients.
-- **E2HS**(Execution Layer History) - **full execution layer history** for execution clients, provides data from genesis to latest, headers provide proofs of canonicalness [ ⚠️ Under Development ].
+- [**E2HS**(Execution Layer History)](./formats/e2hs.md) - **full execution layer history** for execution clients, provides data from genesis to latest, headers are accompanied by proofs of canonicalness.
 - **Erb**(Blob) - Era file equivalent for blob sidecars [ ⚠️ Under Development ].
 
 ## E2store Types

--- a/formats/e2hs.md
+++ b/formats/e2hs.md
@@ -8,7 +8,7 @@
 
  The structure can be summarized through this definition:
 
-	era1 := Version | block-tuple* | other-entries* | BlockIndex
+	e2hs := Version | block-tuple* | other-entries* | BlockIndex
 	block-tuple :=  CompressedHeaderWithProof | CompressedBody | CompressedReceipts
 
  Each basic element is its own entry:
@@ -17,7 +17,7 @@
 	CompressedHeaderWithProof   = { type: 0x0301, data: snappyFramed(ssz(header_with_proof)) }
 	CompressedBody              = { type: 0x0400, data: snappyFramed(rlp(body)) }
 	CompressedReceipts          = { type: 0x0500, data: snappyFramed(rlp(receipts)) }
-	BlockIndex                  = { type: 0x3266, data: block-index }
+	BlockIndex                  = { type: 0x6632, data: block-index }
 
  The `header_with_proof` type definition can be found in the Portal Network [documentation](https://github.com/ethereum/portal-network-specs/blob/master/history/history-network.md#block-header).
 
@@ -30,4 +30,12 @@
  defined relative to index's location in the file. The total number of block
  entries in the file is recorded in count.
 
- The maximum number of blocks in an E2HS file is 8192.
+ Every E2HS file must contain a contiguous section of 8192 blocks.
+
+ ### File Naming Convention
+ `<config-name>-<era-number>-<hash>.e2hs`
+
+ Where:
+ - `config-name`: Network configuration identifier (e.g., mainnet, sepolia) 
+ - `era-number`: Sequential epoch identifier
+ - `hash`: short hash of e2hs file

--- a/formats/e2hs.md
+++ b/formats/e2hs.md
@@ -33,9 +33,9 @@
  Every E2HS file must contain a contiguous section of 8192 blocks.
 
  ### File Naming Convention
- `<config-name>-<era-number>-<hash>.e2hs`
+ `<config-name>-<era-number>-<short-hash>.e2hs`
 
  Where:
  - `config-name`: Network configuration identifier (e.g., mainnet, sepolia) 
  - `era-number`: Sequential epoch identifier
- - `hash`: short hash of e2hs file
+ - `short-hash`: first 4 bytes of the first block header included in this file

--- a/formats/e2hs.md
+++ b/formats/e2hs.md
@@ -13,13 +13,13 @@
 
  Each basic element is its own entry:
 
-	Version                     = { type: 0x6532, data: nil }
-	CompressedHeaderWithProof   = { type: 0x0301, data: snappyFramed(ssz(header_with_proof)) }
-	CompressedBody              = { type: 0x0400, data: snappyFramed(rlp(body)) }
-	CompressedReceipts          = { type: 0x0500, data: snappyFramed(rlp(receipts)) }
-	BlockIndex                  = { type: 0x6632, data: block-index }
+	Version                     = { type: [0x65, 0x32], data: nil }
+	CompressedHeaderWithProof   = { type: [0x03, 0x01], data: snappyFramed(ssz(header_with_proof)) }
+	CompressedBody              = { type: [0x04, 0x00], data: snappyFramed(rlp(body)) }
+	CompressedReceipts          = { type: [0x05, 0x00], data: snappyFramed(rlp(receipts)) }
+	BlockIndex                  = { type: [0x66, 0x32], data: block-index }
 
- The `header_with_proof` type definition can be found in the Portal Network [documentation](https://github.com/ethereum/portal-network-specs/blob/master/history/history-network.md#block-header).
+ The `header_with_proof` type definition can be found in the Portal Network [documentation](https://github.com/ethereum/portal-network-specs/blob/650b65f5893930bbf4b0f08edd53fae19f0938ba/history/history-network.md#block-header).
 
  `BlockIndex` stores relative offsets to each compressed block entry. The
  format is:
@@ -30,6 +30,8 @@
  defined relative to index's location in the file. The total number of block
  entries in the file is recorded in count.
 
+ `other-entries` is an extension point for future record types in the `e2hs` format. The positioning of these allows the indices to continue to be looked up from the back of the group.
+
  Every E2HS file must contain a contiguous section of 8192 blocks.
 
  ### File Naming Convention
@@ -38,4 +40,4 @@
  Where:
  - `config-name`: Network configuration identifier (e.g., mainnet, sepolia) 
  - `era-number`: Sequential epoch identifier
- - `short-hash`: first 4 bytes of the first block header included in this file
+ - `short-hash`: first 4 bytes of the last block header's hash included in this file

--- a/formats/e2hs.md
+++ b/formats/e2hs.md
@@ -1,0 +1,33 @@
+# E2HS files
+
+ E2HS files are themselves e2store files. For more information on this format,
+ see the [documentation](https:github.com/status-im/nimbus-eth2/blob/stable/docs/e2store.md).
+
+ The overall structure of an E2HS file follows closely the structure of an Era file
+ which contains consensus Layer data (and as a byproduct, EL data after the merge).
+
+ The structure can be summarized through this definition:
+
+	era1 := Version | block-tuple* | other-entries* | BlockIndex
+	block-tuple :=  CompressedHeaderWithProof | CompressedBody | CompressedReceipts
+
+ Each basic element is its own entry:
+
+	Version                     = { type: 0x6532, data: nil }
+	CompressedHeaderWithProof   = { type: 0x0301, data: snappyFramed(ssz(header_with_proof)) }
+	CompressedBody              = { type: 0x0400, data: snappyFramed(rlp(body)) }
+	CompressedReceipts          = { type: 0x0500, data: snappyFramed(rlp(receipts)) }
+	BlockIndex                  = { type: 0x3266, data: block-index }
+
+ The `header_with_proof` type definition can be found in the Portal Network [documentation](https://github.com/ethereum/portal-network-specs/blob/master/history/history-network.md#block-header).
+
+ `BlockIndex` stores relative offsets to each compressed block entry. The
+ format is:
+
+	block-index := starting-number | index | index | index ... | count
+
+ `starting-number` is the first block number in the archive. Every index is a
+ defined relative to index's location in the file. The total number of block
+ entries in the file is recorded in count.
+
+ The maximum number of blocks in an E2HS file is 8192.

--- a/types/0x0301.md
+++ b/types/0x0301.md
@@ -1,0 +1,8 @@
+# CompressedHeaderWithProof
+
+```
+type: [0x03, 0x01]
+data: snappyFramed(ssz(header_with_proof))
+```
+
+`CompressedHeaderWithProof` entries contain a snappy compressed ssz execution header with proof. The `header_with_proof` type definition can be found in the Portal Network [documentation](https://github.com/ethereum/portal-network-specs/blob/master/history/history-network.md#block-header).

--- a/types/README.md
+++ b/types/README.md
@@ -7,12 +7,13 @@ This is a sorted list by type number
 | [0x0100](0x0100.md)  | CompressedSignedBeaconBlock | [Era](../formats/era.md)  |   |
 | [0x0200](0x0200.md)  | CompressedBeaconState | [Era](../formats/era.md)  |   |
 | [0x0300](0x0300.md)  | CompressedHeader | [Era1](../formats/era1.md), [E2SS](../formats/e2ss.md) |   |
-| [0x0400](0x0400.md)  | CompressedBody | [Era1](../formats/era1.md)  |   |
-| [0x0500](0x0500.md)  | CompressedReceipts | [Era1](../formats/era1.md)  |   |
+| [0x0301](0x0301.md)  | CompressedHeaderWithProof | [E2HS](../formats/e2hs.md) |   |
+| [0x0400](0x0400.md)  | CompressedBody | [Era1](../formats/era1.md), [E2HS](../formats/e2hs.ms)  |   |
+| [0x0500](0x0500.md)  | CompressedReceipts | [Era1](../formats/era1.md), [E2HS](../formats/e2hs.ms)  |   |
 | [0x0600](0x0600.md)  | TotalDifficulty | [Era1](../formats/era1.md)  |   |
 | [0x0700](0x0700.md)  | Accumulator | [Era1](../formats/era1.md)  |   |
 | [0x0800](0x0800.md)  | CompressedAccount | [E2SS](../formats/e2ss.md)  |   |
 | [0x0900](0x0900.md)  | CompressedStorage | [E2SS](../formats/e2ss.md)  |   |
 | [0x6532](0x6532.md)  | Version | ALL  |   |
-| [0x6632](0x6632.md)  | BlockIndex | [Era1](../formats/era1.md)  |   |
+| [0x6632](0x6632.md)  | BlockIndex | [Era1](../formats/era1.md), [E2HS](../formats/e2hs.ms)  |   |
 | [0x6932](0x6932.md)  | SlotIndex | [Era](../formats/era.md)  |   |


### PR DESCRIPTION
Add the specification for the new `E2HS` file format, used in the Portal Network history network. Previous discussion around this format can be found [here](https://github.com/ethereum/portal-network-specs/pull/368/).