### PR TITLE
Typo in 0x0900.md

### DIFF
--- a/types/0x0900.md
+++ b/types/0x0900.md
@@ -1,7 +1,7 @@
 # CompressedStorage
 
 ```
-type: [0x08, 0x00]
+type: [0x09, 0x00]
 data: snappyFramed(rlp(Vec<StorageItem>)) 
 ```
 


### PR DESCRIPTION
I was looking around the repo in order to implement parsing for e2ss files when I noticed that the CompressedStorage had an identifier 0x08 I think that's a typo

https://github.com/eth-clients/e2store-format-specs/blob/main/formats/e2ss.md 

This is the repo that I based my reason, in the repo the type indentifier is [0x09, 0x00]