### PR TITLE
Define Erb filetype for historical blobs and data columns

### DIFF
--- a/types/0x0101.md
+++ b/types/0x0101.md
@@ -1,0 +1,10 @@
+# CompressedBlobSidecar
+
+```
+type: [0x01, 0x01]
+data: ssz(List[snappyFramed(BlobSidecar), MAX_BLOBS_PER_BLOCK | MAX_BLOBS_PER_BLOCK_ELECTRA])
+```
+
+`CompressedBlobSidecar`s contains `BlobSidecar` objects encoded using SSZ then compressed using the snappy [framing format](https://github.com/google/snappy/blob/master/framing_format.txt). The SSZ datatype of `data` is `List[List[byte, 262144], MAX_BLOBS_PER_BLOCK | MAX_BLOBS_PER_BLOCK_ELECTRA]`. The maximum length of the inner `List` is `2**18`, which accommodates a maximally sized `BlobSidecar` with some overhead in case of inefficient snappy encoding. The maximum length of the outer list is fork-dependent, and should be determined dynamically based on the `slot` of the first `BlobSidecar`.
+
+The encoding of each list element matches the `response_chunk` encoding for `BlobSidecarsByRoot` and `BlobSidecarsByRange` requests from the p2p specification.

--- a/types/README.md
+++ b/types/README.md
@@ -5,6 +5,8 @@ This is a sorted list by type number
 |---|---|---|---|
 | [0x0000](0x0000.md)  | Empty | None  |   |
 | [0x0100](0x0100.md)  | CompressedSignedBeaconBlock | [Era](../formats/era.md)  |   |
+| [0x0101](0x0101.md)  | CompressedBlobSidecar | TODO: Erb |   |
+| [0x0102](0x0102.md)  | CompressedDataColumnSidecar | TODO: Erb |   |
 | [0x0200](0x0200.md)  | CompressedBeaconState | [Era](../formats/era.md)  |   |
 | [0x0300](0x0300.md)  | CompressedHeader | [Era1](../formats/era1.md), [E2SS](../formats/e2ss.md) |   |
 | [0x0301](0x0301.md)  | CompressedHeaderWithProof | [E2HS](../formats/e2hs.md) |   |


### PR DESCRIPTION
- [x] New type `0x0101` for `CompressedBlobSidecar`
- [ ] New type `0x0102` for `CompressedDataColumnSidecar`
- [ ] File format for `.erb`